### PR TITLE
Use correct HTTP methods for RESTful API (issue #7)

### DIFF
--- a/src/rest/service.rs
+++ b/src/rest/service.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use axum::{Extension, Json};
 use axum::extract::{Path, Query};
-use axum::routing::{get, post, put};
+use axum::routing::{get, patch, post};
 use axum_route_error::RouteError;
 use axum::http::StatusCode;
 use crate::dto::{Code, Location, RegistrationResponse, RegistrationStatus};
@@ -20,9 +20,9 @@ where
     axum::Router::new()
         .route("/{id}", get(get_user::<U, S>))
         .route("/external/{external_id}", get(get_external_user::<U, S>))
-        .route("/external", put(register_user::<U, S>))
-        .route("/{id}/language/{code}", post(update_language::<U, S>))
-        .route("/{id}/location/", post(update_location::<U, S>))
+        .route("/external", post(register_user::<U, S>))
+        .route("/{id}/language/{code}", patch(update_language::<U, S>))
+        .route("/{id}/location/", patch(update_location::<U, S>))
         .route("/{id}/premium/activate/{variant}", post(activate_premium::<U, S>))
         .layer(Extension(repos))
 }

--- a/src/rest/test.rs
+++ b/src/rest/test.rs
@@ -60,7 +60,7 @@ impl UserServiceClient {
         let app = self.router.clone();
         let response = app.oneshot(
             Request::builder()
-                .method(http::Method::PUT)
+                .method(http::Method::POST)
                 .uri("/external")
                 .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                 .body(Body::from(
@@ -84,7 +84,7 @@ impl UserServiceClient {
         let app = self.router.clone();
         let response = app.oneshot(
             Request::builder()
-                .method(http::Method::POST)
+                .method(http::Method::PATCH)
                 .uri(format!("/{user_id}/language/{code}"))
                 .body(Body::empty())?
         ).await?;
@@ -96,7 +96,7 @@ impl UserServiceClient {
         let app = self.router.clone();
         let response = app.oneshot(
             Request::builder()
-                .method(http::Method::POST)
+                .method(http::Method::PATCH)
                 .uri(format!("/{user_id}/location/?latitude={latitude}&longitude={longitude}"))
                 .body(Body::empty())?
         ).await?;


### PR DESCRIPTION
Replace PUT with POST for user registration, and POST with PATCH for partial updates to language and location fields.